### PR TITLE
Update project name and remove virtual host from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # amqp-poc-subscriber
+
+## Build 
+
+```bash
+./gradlew clean assemble
+```
+
+## Run
+
+```bash
+java -jar build/libs/amqp.poc-subscriber-0.0.1-SNAPSHOT.jar
+```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'amqp.poc'
+rootProject.name = 'amqp.poc-subscriber'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,5 @@ spring.rabbitmq.host=127.0.0.1
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
-spring.rabbitmq.virtual-host=default
 
 rabbitmq.poc.exchange=poc.messages


### PR DESCRIPTION
Removing virtual host it will connect to any host managed by RabbitMQ. I think is better for testing.
Also I rename the project to `amqp.poc-subscriber` and I wrote how to build the project and run from project root.